### PR TITLE
Bump to 0.2.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,8 +54,6 @@ jobs:
       - name: Publish to npm
         if: steps.version.outputs.changed == 'true'
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create GitHub Release
         if: steps.version.outputs.changed == 'true'

--- a/lat.md/dev-process.md
+++ b/lat.md/dev-process.md
@@ -62,4 +62,4 @@ GitHub Actions workflow at `.github/workflows/publish.yml`. Runs on every push t
 3. **Publish to npm** — `pnpm publish --no-git-checks` using the `NPM_TOKEN` repository secret
 4. **Create GitHub release** — tags `vX.Y.Z` and creates a GitHub release with auto-generated notes
 
-Uses npm trusted publishing with OIDC provenance — the `--provenance` flag signs the package with the GitHub Actions identity. Requires an `NPM_TOKEN` secret in the repository settings (automation token from npmjs.com). The package is linked to the `1st1/lat.md` repo on npmjs.com under Settings → Publishing Access.
+Uses npm trusted publishing (OIDC) — no secrets needed. The `--provenance` flag signs and publishes the package using the GitHub Actions identity. The `lat.md` package is linked to the `1st1/lat.md` repo on npmjs.com under Settings → Publishing Access.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lat.md",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "A knowledge graph for your codebase, written in markdown",
   "type": "module",
   "packageManager": "pnpm@10.30.2",


### PR DESCRIPTION
## Changelog

### New features
- **Subdirectory support** — `lat.md/` vault can now have nested directories with vault-relative section IDs (e.g. `guides/setup#Install`)
- **Obsidian-style short refs** — `[[setup#Install]]` resolves automatically when the file stem is unique; ambiguous refs produce actionable error messages with candidate paths
- **Directory index validation** — `lat check index` enforces that every folder has a `<folder>.md` index file with a bullet-point listing of contents
- **Shared file walker** — single `walkEntries()` with `.gitignore` support and FS memoization
- **Automated release workflow** — `publish.yml` with npm trusted publishing (OIDC provenance)

### Improvements
- Structured error output — check errors render as a markdown-like bullet list with indented context
- Error fixture naming convention — test cases that assert errors use `error-` prefix
- Test conventions documented in `lat.md/tests/tests.md`
- `lat.md/tests/` split from single file into per-topic test spec files

### Docs
- npm badge in README
- `AGENTS.md` template synced and dogfooded
- Website: OG tags, mobile tweaks, open-source mention

### Fix
- Switch to pure OIDC trusted publishing (no NPM_TOKEN secret needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)