### PR TITLE
Support LAT_LLM_KEY_FILE and LAT_LLM_KEY_HELPER for API key resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,13 @@ npm install -g lat.md
 
 Or use directly with `npx lat.md@latest <command>`.
 
-For semantic search (`lat search`), set the `LAT_LLM_KEY` environment variable with an OpenAI (`sk-...`) or Vercel AI Gateway (`vck_...`) API key.
+For semantic search (`lat search`), provide an OpenAI (`sk-...`) or Vercel AI Gateway (`vck_...`) API key via one of:
+
+```bash
+export LAT_LLM_KEY=sk-...                # direct value
+export LAT_LLM_KEY_FILE=~/.secrets/lat    # path to a file containing the key
+export LAT_LLM_KEY_HELPER='security find-generic-password -a "$USER" -s "LAT_LLM_KEY" -w'  # command that prints the key
+```
 
 ## How it works
 

--- a/lat.md/cli.md
+++ b/lat.md/cli.md
@@ -114,13 +114,19 @@ Implementation: `src/cli/search.ts`, core logic in `src/search/`
 
 ### Provider Detection
 
-Requires `LAT_LLM_KEY` env var. Provider is auto-detected from key prefix:
+Requires an API key. The key is resolved in priority order by `resolveApiKey()` (`src/resolve-key.ts`):
+
+1. `LAT_LLM_KEY` env var — direct value
+2. `LAT_LLM_KEY_FILE` env var — path to a file containing the key (read and trimmed)
+3. `LAT_LLM_KEY_HELPER` env var — shell command that prints the key to stdout (10 s timeout)
+
+Provider is auto-detected from the resolved key prefix:
 - `sk-...` — OpenAI (uses `text-embedding-3-small`, 1536 dims)
 - `vck_...` — Vercel AI Gateway (uses `openai/text-embedding-3-small`, 1536 dims)
 - `sk-ant-...` — Anthropic (not supported, errors with guidance)
 - `REPLAY_LAT_LLM_KEY::<url>` — test-only replay server for offline testing
 
-Implementation: `src/search/provider.ts`
+Implementation: `src/search/provider.ts`, `src/resolve-key.ts`
 
 ### Embeddings
 

--- a/scripts/cook-test-rag.ts
+++ b/scripts/cook-test-rag.ts
@@ -4,13 +4,18 @@
  * Runs the search test in capture mode — proxies to the real embedding API
  * (via LAT_LLM_KEY) and records all vectors to tests/cases/rag/replay-data/.
  *
- * Usage: pnpm cook-test-rag  (requires LAT_LLM_KEY in env)
+ * Usage: pnpm cook-test-rag  (requires LAT_LLM_KEY, LAT_LLM_KEY_FILE, or LAT_LLM_KEY_HELPER)
  */
 
 import { execSync } from 'node:child_process';
+import { resolveApiKey } from '../src/resolve-key.js';
 
-if (!process.env.LAT_LLM_KEY) {
-  console.error('LAT_LLM_KEY must be set to a real API key');
+try {
+  // Resolve once up front so capture mode has a direct key value.
+  const key = resolveApiKey();
+  process.env.LAT_LLM_KEY = key;
+} catch (err) {
+  console.error((err as Error).message);
   process.exit(1);
 }
 

--- a/src/cli/search.ts
+++ b/src/cli/search.ts
@@ -6,19 +6,18 @@ import { indexSections } from '../search/index.js';
 import { searchSections } from '../search/search.js';
 import { loadAllSections, flattenSections } from '../lattice.js';
 import { formatResultList } from '../format.js';
+import { resolveApiKey } from '../resolve-key.js';
 
 export async function searchCmd(
   ctx: CliContext,
   query: string | undefined,
   opts: { limit: number; reindex?: boolean },
 ): Promise<void> {
-  const key = process.env.LAT_LLM_KEY;
-  if (!key) {
-    console.error(
-      chalk.red(
-        'LAT_LLM_KEY is not set. Set it to an OpenAI (sk-...) or Vercel AI (vck_...) key.',
-      ),
-    );
+  let key: string;
+  try {
+    key = resolveApiKey();
+  } catch (err) {
+    console.error(chalk.red((err as Error).message));
     process.exit(1);
   }
 

--- a/src/resolve-key.ts
+++ b/src/resolve-key.ts
@@ -1,0 +1,38 @@
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+/**
+ * Resolve the LLM API key from, in priority order:
+ *   1. LAT_LLM_KEY          — direct value
+ *   2. LAT_LLM_KEY_FILE     — path to a file containing the key
+ *   3. LAT_LLM_KEY_HELPER   — shell command that prints the key
+ */
+export function resolveApiKey(): string {
+  const key = process.env.LAT_LLM_KEY;
+  if (key) return key;
+
+  const file = process.env.LAT_LLM_KEY_FILE;
+  if (file) {
+    const content = readFileSync(file, 'utf-8').trim();
+    if (!content) {
+      throw new Error(`LAT_LLM_KEY_FILE (${file}) is empty.`);
+    }
+    return content;
+  }
+
+  const helper = process.env.LAT_LLM_KEY_HELPER;
+  if (helper) {
+    const result = execSync(helper, {
+      encoding: 'utf-8',
+      timeout: 10_000,
+    }).trim();
+    if (!result) {
+      throw new Error('LAT_LLM_KEY_HELPER command returned an empty string.');
+    }
+    return result;
+  }
+
+  throw new Error(
+    'LAT_LLM_KEY is not set. Provide the key via LAT_LLM_KEY, LAT_LLM_KEY_FILE, or LAT_LLM_KEY_HELPER.',
+  );
+}

--- a/templates/AGENTS.md
+++ b/templates/AGENTS.md
@@ -29,7 +29,7 @@ lat check                      # validate all links and code refs
 
 Run `lat --help` when in doubt about available commands or options.
 
-If `lat search` fails because `LAT_LLM_KEY` is not set, explain to the user that semantic search requires an API key (`export LAT_LLM_KEY=sk-...` for OpenAI or `export LAT_LLM_KEY=vck_...` for Vercel). If the user doesn't want to set it up, use `lat locate` for direct lookups instead.
+If `lat search` fails because no API key is configured, explain to the user that semantic search requires a key provided via `LAT_LLM_KEY` (direct value), `LAT_LLM_KEY_FILE` (path to key file), or `LAT_LLM_KEY_HELPER` (command that prints the key). Supported key prefixes: `sk-...` (OpenAI) or `vck_...` (Vercel). If the user doesn't want to set it up, use `lat locate` for direct lookups instead.
 
 # Syntax primer
 


### PR DESCRIPTION
Allow the embedding API key to come from a file or a helper command
instead of only a plain environment variable. Priority order:
LAT_LLM_KEY > LAT_LLM_KEY_FILE > LAT_LLM_KEY_HELPER.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
