### PR TITLE
Fix top-level key for MCP server configuration in VS Code

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -139,7 +139,10 @@ function mcpCommand(): { command: string; args: string[] } {
 
 // ── MCP config helpers ───────────────────────────────────────────────
 
-type McpConfig = Record<string, Record<string, { command: string; args: string[] }>>;
+type McpConfig = Record<
+  string,
+  Record<string, { command: string; args: string[] }>
+>;
 
 function hasMcpServer(configPath: string, key: string): boolean {
   if (!existsSync(configPath)) return false;


### PR DESCRIPTION
In Cursor and Claude Code, the top-level key in the JSON config is `"mcpServers": {}`. But in VS Code it is `"servers": {}`. The pull request fixes the initialization of the VS Code config.

## Changed
* additional string argument `key` in the `hasMcpServer()` and `addMcpServer()` functions. This argument is `mcpServers` for the initialization of Cursor and Claude Code, but `servers` for VS Code.