### PR TITLE
Release 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lat.md",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "A knowledge graph for your codebase, written in markdown",
   "type": "module",
   "packageManager": "pnpm@10.30.2",


### PR DESCRIPTION
## Summary

- **Fix section IDs to include h1 heading** — canonical form is now `file#H1#H2` instead of `file#H2`. Short-form refs like `[[file#H2]]` still resolve via implicit root heading insertion.
- **Index files use wiki links** — entries now use `- [[name]] — description` instead of `- **name.md** — description`, making indexes part of the wiki link graph.
- **Suggest `lat init`** when no `lat.md/` directory is found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)