### PR TITLE
Release 0.7.1

### DIFF
--- a/lat.md/dev-process.md
+++ b/lat.md/dev-process.md
@@ -51,7 +51,7 @@ Published to npm as `lat.md`. The `bin` entry exposes the `lat` command. Only `d
 
 ### Release Process
 
-How to publish a new version:
+Step-by-step procedure for cutting a release: version bump, changelog, PR, and npm publish.
 
 1. **Compile changelog** — run `git log --oneline` since the last version bump commit (look for commits matching `Bump to X.Y.Z`) and summarize notable changes as bullet points. Only include user-facing features, fixes, and behavioral changes — skip doc-only updates, refactors, and other commits that don't affect functionality
 2. **Sync main** — `git fetch` and rebase/merge to ensure local `main` is up to date with the remote before branching

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lat.md",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A knowledge graph for your codebase, written in markdown",
   "type": "module",
   "packageManager": "pnpm@10.30.2",


### PR DESCRIPTION
## Summary

* **Fix**: `lat section` displayed frontmatter instead of content for files with YAML frontmatter — replaced regex-based `stripFrontmatter` with `remark-frontmatter` so AST line positions are correct
* **Improve**: Command output uses markdown `##` headings and blockquoted section content for better rendering in AI agents
* **Add**: Navigation hints footer to `lat section` (matching `lat search`), extracted as shared `formatNavHints` helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)