### PR TITLE
Release 0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lat.md",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A knowledge graph for your codebase, written in markdown",
   "type": "module",
   "packageManager": "pnpm@10.30.2",


### PR DESCRIPTION
## Summary

- Fix `lat init` crash when readline and selectMenu share stdin — `selectMenu` puts stdin into raw mode with its own `data` listener, which corrupts any co-existing readline interface, causing `rl.question()` to exit the process. Deferred readline creation to after the selectMenu loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)