### PR TITLE
Test both ripgrep and TS fallback paths for code-ref scanning

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,10 @@ jobs:
         if: steps.version.outputs.changed == 'true'
         run: npm install -g npm@latest
 
+      - name: Install ripgrep
+        if: steps.version.outputs.changed == 'true'
+        run: sudo apt-get install -y ripgrep
+
       - name: Install dependencies
         if: steps.version.outputs.changed == 'true'
         run: pnpm install --frozen-lockfile

--- a/lat.md/dev-process.md
+++ b/lat.md/dev-process.md
@@ -39,7 +39,7 @@ It wraps the `ignore-walk` npm package to ensure `.gitignore` rules are consiste
 
 [[src/code-refs.ts#walkFiles]] calls `walkEntries()` then additionally skips `.md` files, `lat.md/`, `.claude/`, and sub-projects (directories containing their own `lat.md/`).
 
-[[src/code-refs.ts#scanCodeRefs]] uses a two-tier strategy for finding `@lat:` comments: it first tries `rg` (ripgrep), falling back to a pure TypeScript implementation. When rg is available, it handles both searching and file listing — `walkFiles` is not called. Exclusions for `lat.md/`, `.claude/`, `*.md`, and sub-projects are passed as `--glob` args to rg. Sub-projects are detected upfront via `rg --files` (directories containing a nested `lat.md/`). The TS fallback uses `walkFiles` for both file discovery and exclusion filtering. `CodeRef.file` is always stored as a projectRoot-relative path; consumers convert to cwd-relative only at display time.
+[[src/code-refs.ts#scanCodeRefs]] uses a two-tier strategy for finding `@lat:` comments: it first tries `rg` (ripgrep), falling back to a pure TypeScript implementation. When rg is available, it handles both searching and file listing — `walkFiles` is not called. Exclusions for `lat.md/`, `.claude/`, `*.md`, and sub-projects are passed as `--glob` args to rg. Sub-projects are detected upfront via `rg --files` (directories containing a nested `lat.md/`). The TS fallback uses `walkFiles` for both file discovery and exclusion filtering. `CodeRef.file` is always stored as a projectRoot-relative path; consumers convert to cwd-relative only at display time. Setting `_LAT_DISABLE_RG=1` forces the TS fallback; used in tests to cover both paths.
 
 [[src/cli/check.ts#checkIndex]] calls `walkEntries()` on the `lat.md/` directory itself to discover visible entries for index validation.
 
@@ -71,7 +71,8 @@ Version numbers follow semver. While pre-1.0, bump the patch for fixes and the m
 GitHub Actions workflow at `.github/workflows/publish.yml`. Runs on every push to `main`:
 
 1. **Detect version change** — compares `version` in `package.json` against the previous commit. If unchanged, skips all publish steps
-2. **Run tests** — `pnpm install`, `pnpm build`, `pnpm vitest run`
+2. **Install ripgrep** — `apt-get install ripgrep` so both rg and TS-fallback code paths are exercised
+3. **Run tests** — `pnpm install`, `pnpm build`, `pnpm vitest run`
 3. **Publish to npm** — `pnpm publish --no-git-checks` using the `NPM_TOKEN` repository secret
 4. **Create GitHub release** — tags `vX.Y.Z` and creates a GitHub release with auto-generated notes
 

--- a/lat.md/tests/tests.md
+++ b/lat.md/tests/tests.md
@@ -28,3 +28,4 @@ Shared patterns for writing and organizing tests in this project.
 - [[check-sections]] — Validating section leading paragraphs
 - [[section]] — getSection core function and formatSectionOutput formatter
 - [[hook]] — Stop hook conditional blocking and diff analysis
+- [[ts-fallback]] — Pure-TypeScript code-ref scanner fallback without ripgrep

--- a/lat.md/tests/ts-fallback.md
+++ b/lat.md/tests/ts-fallback.md
@@ -1,0 +1,28 @@
+---
+lat:
+  require-code-mention: true
+---
+
+# TS Fallback
+
+Tests that verify the pure-TypeScript code-ref scanner produces identical results to the ripgrep path.
+
+## scanCodeRefs finds refs without rg
+
+With `_LAT_DISABLE_RG=1`, `scanCodeRefs` still finds all `@lat:` refs in Python files, returning correct targets, file paths, and line numbers.
+
+## checkCodeRefs detects dangling ref without rg
+
+With `_LAT_DISABLE_RG=1`, `checkCodeRefs` still detects `@lat:` comments pointing to nonexistent sections.
+
+## gitignore filtering works without rg
+
+With `_LAT_DISABLE_RG=1`, `scanCodeRefs` still respects `.gitignore` rules, skipping ignored directories and returning only visible source files.
+
+## findRefs with code scope works without rg
+
+With `_LAT_DISABLE_RG=1`, `findRefs` with `code` scope still finds `@lat:` back-references for a given section.
+
+## getSection includes code back-refs without rg
+
+With `_LAT_DISABLE_RG=1`, `getSection` still populates `codeRefs` with `@lat:` back-references from source files.

--- a/src/code-refs.ts
+++ b/src/code-refs.ts
@@ -251,9 +251,12 @@ async function scanWithTs(
 
 export async function scanCodeRefs(projectRoot: string): Promise<ScanResult> {
   // Fast path: use rg for both searching and file listing
-  const rgResult = await tryRipgrep(projectRoot);
-  if (rgResult !== null) {
-    return { refs: rgResult.refs, files: rgResult.files };
+  // _LAT_DISABLE_RG is a test-only escape hatch to force the TS fallback
+  if (!process.env._LAT_DISABLE_RG) {
+    const rgResult = await tryRipgrep(projectRoot);
+    if (rgResult !== null) {
+      return { refs: rgResult.refs, files: rgResult.files };
+    }
   }
 
   // Fallback: walk files ourselves and scan with TS

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { execSync } from 'child_process';
 import { dirname, join } from 'node:path';
 import {
@@ -1136,5 +1136,72 @@ describe('error-non-md-file', () => {
     for (const err of indexErrors) {
       expect(err.snippet ?? '').not.toContain('README');
     }
+  });
+});
+
+// --- scanCodeRefs TS fallback (no rg) ---
+// Re-runs a representative subset of code-ref tests with ripgrep disabled
+// to ensure the pure-TypeScript scanner produces identical results.
+
+describe('scanCodeRefs TS fallback (_LAT_DISABLE_RG)', () => {
+  let origEnv: string | undefined;
+
+  beforeAll(() => {
+    origEnv = process.env._LAT_DISABLE_RG;
+    process.env._LAT_DISABLE_RG = '1';
+  });
+
+  afterAll(() => {
+    if (origEnv === undefined) {
+      delete process.env._LAT_DISABLE_RG;
+    } else {
+      process.env._LAT_DISABLE_RG = origEnv;
+    }
+  });
+
+  // @lat: [[tests/ts-fallback#scanCodeRefs finds refs without rg]]
+  it('scanCodeRefs finds refs without rg', async () => {
+    const { refs } = await scanCodeRefs(caseDir('python-code-ref'));
+    expect(refs).toHaveLength(2);
+    expect(refs[0].target).toBe('Specs#Feature A');
+    expect(refs[0].file).toContain('app.py');
+    expect(refs[1].target).toBe('Specs#Nonexistent');
+  });
+
+  // @lat: [[tests/ts-fallback#checkCodeRefs detects dangling ref without rg]]
+  it('checkCodeRefs detects dangling ref without rg', async () => {
+    const { errors } = await checkCodeRefs(latDir('error-dangling-code-ref'));
+    const dangling = errors.filter((e) => e.target === 'Alpha#Nonexistent');
+    expect(dangling).toHaveLength(1);
+    expect(dangling[0].message).toContain('no matching section found');
+  });
+
+  // @lat: [[tests/ts-fallback#gitignore filtering works without rg]]
+  it('gitignore filtering works without rg', async () => {
+    const { refs, files } = await scanCodeRefs(caseDir('gitignore-filtering'));
+    expect(refs).toHaveLength(1);
+    expect(refs[0].file).toContain('src/app.ts');
+    expect(files).toHaveLength(1);
+  });
+
+  // @lat: [[tests/ts-fallback#findRefs with code scope works without rg]]
+  it('findRefs with code scope works without rg', async () => {
+    const result = await findRefs(
+      testCtx('short-ref'),
+      'setup#Configure',
+      'code',
+    );
+    expect(result.kind).toBe('found');
+    if (result.kind !== 'found') return;
+    expect(result.codeRefs.length).toBeGreaterThan(0);
+  });
+
+  // @lat: [[tests/ts-fallback#getSection includes code back-refs without rg]]
+  it('getSection includes code back-refs without rg', async () => {
+    const result = await getSection(testCtx('short-ref'), 'setup#Configure');
+    expect(result.kind).toBe('found');
+    if (result.kind !== 'found') return;
+    expect(result.codeRefs.length).toBeGreaterThan(0);
+    expect(result.codeRefs[0].file).toContain('app.ts');
   });
 });


### PR DESCRIPTION
Add _LAT_DISABLE_RG env var to force the pure-TypeScript scanner. New test suite re-runs representative code-ref tests (scanCodeRefs, checkCodeRefs, gitignore filtering, findRefs, getSection) with rg disabled to ensure both paths produce identical results.

Install ripgrep in CI so the rg path is exercised in publish workflow.