### PR TITLE
Bump to 0.10.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lat.md",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "A knowledge graph for your codebase, written in markdown",
   "type": "module",
   "packageManager": "pnpm@10.30.2",


### PR DESCRIPTION
## Summary

- Show source ref line ranges in `lat section` output (e.g. `file.ts:10-25`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)