### PR TITLE
Enhance lat_check MCP tool with optional scope parameter

### DIFF
--- a/lat.md/cli.md
+++ b/lat.md/cli.md
@@ -291,7 +291,7 @@ Clients invoke this as `lat mcp`. The `lat init` wizard registers the MCP server
 - **lat_section** — show section content with outgoing/incoming refs (wraps [[cli#section]])
 - **lat_search** — semantic search across sections (wraps [[cli#search]])
 - **lat_expand** — expand `[[refs]]` in text (wraps [[cli#expand]])
-- **lat_check** — validate links and code refs (wraps [[cli#check]])
+- **lat_check** — validate links, code refs, indexes, and/or sections (wraps [[cli#check]]). Optional `scope` parameter: `all` (default), `md`, `code-refs`, `index`, `sections`
 - **lat_refs** — find references to a section (wraps [[cli#refs]])
 
 Each MCP tool calls the same command function as the CLI (e.g. `locateCommand`, `refsCommand`, `searchCommand`), passing a `CmdContext` with `plainStyler` and `mode: 'mcp'`. The `toMcp()` helper converts `CmdResult` to MCP response format. Uses `@modelcontextprotocol/sdk` with stdio transport. Resolves `lat.md/` from cwd.

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -8,7 +8,13 @@ import { locateCommand } from '../cli/locate.js';
 import { sectionCommand } from '../cli/section.js';
 import { searchCommand } from '../cli/search.js';
 import { expandCommand } from '../cli/expand.js';
-import { checkAllCommand } from '../cli/check.js';
+import {
+  checkAllCommand,
+  checkCodeRefsCommand,
+  checkIndexCommand,
+  checkMdCommand,
+  checkSectionsCommand,
+} from '../cli/check.js';
 import { refsCommand, type Scope } from '../cli/refs.js';
 
 function toMcp(result: CmdResult) {
@@ -75,9 +81,30 @@ export async function startMcpServer(): Promise<void> {
 
   server.tool(
     'lat_check',
-    'Validate all wiki links, code references, and directory indexes in lat.md',
-    {},
-    async () => toMcp(await checkAllCommand(ctx)),
+    'Validate wiki links, code references, directory indexes, and/or section structure in lat.md',
+    {
+      scope: z
+        .enum(['all', 'md', 'code-refs', 'index', 'sections'])
+        .optional()
+        .default('all')
+        .describe(
+          'What to check: all (default), md, code-refs, index, or sections',
+        ),
+    },
+    async ({ scope }: { scope: string }) => {
+      switch (scope) {
+        case 'md':
+          return toMcp(await checkMdCommand(ctx));
+        case 'code-refs':
+          return toMcp(await checkCodeRefsCommand(ctx));
+        case 'index':
+          return toMcp(await checkIndexCommand(ctx));
+        case 'sections':
+          return toMcp(await checkSectionsCommand(ctx));
+        default:
+          return toMcp(await checkAllCommand(ctx));
+      }
+    },
   );
 
   server.tool(


### PR DESCRIPTION
## Added
* Optional `scope` parameter (either `md`, `code-refs`, `index` or `sections`) for `lat_check` MCP tool. Allows for a more granular execution of the `lat check` command on the MCP server. Now the four sub-commands can be called individually.
  * `lat check md`
  * `lat check code-refs`
  * `lat check index`
  * `lat check sections`

Resolves https://github.com/1st1/lat.md/issues/42