### PR TITLE
Fix: Improve error handling in readConfig() to distinguish read vs parse errors

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -22,8 +22,17 @@ export type LatConfig = {
 export function readConfig(): LatConfig {
   const configPath = getConfigPath();
   if (!existsSync(configPath)) return {};
+  let content: string;
   try {
-    return JSON.parse(readFileSync(configPath, 'utf-8'));
+    content = readFileSync(configPath, 'utf-8');
+  } catch (err) {
+    process.stderr.write(
+      `Error: failed to read config ${configPath}: ${(err as Error).message}\n`,
+    );
+    process.exit(1);
+  }
+  try {
+    return JSON.parse(content);
   } catch (err) {
     process.stderr.write(
       `Error: failed to parse config ${configPath}: ${(err as Error).message}\n`,


### PR DESCRIPTION
## Problem

The `readConfig()` function in `src/config.ts` had imprecise error handling. All errors were reported as "failed to parse config", even when the actual error was a file system issue (e.g., permission denied, file is a directory, I/O error) that occurred during `readFileSync()`.

This made it difficult for users to diagnose configuration issues - a permission problem would be reported as a parse error, leading to confusion.

## Solution

Split the error handling into two distinct stages:

1. **File read stage** - First, read the file content using `readFileSync()`. Any errors at this stage (file system issues) are now reported as "failed to read config".
2. **JSON parse stage** - Then, parse the JSON content. Any errors at this stage are reported as "failed to parse config".

## Changes

- `src/config.ts`: Modified `readConfig()` to separate file reading from JSON parsing
- Error messages now correctly distinguish between:
  - "Error: failed to read config..." (file system issues)
  - "Error: failed to parse config..." (invalid JSON)

## Testing

- All existing tests pass (155 tests)
- The change maintains backward compatibility - the same errors are still caught and reported, just with more accurate messages

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>