### PR TITLE
Add `lat check` to the CI pipeline

### DIFF
--- a/.github/workflows/lat-check.yaml
+++ b/.github/workflows/lat-check.yaml
@@ -1,0 +1,12 @@
+name: lat check
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  lat-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: lars20070/lat-check-action@v1


### PR DESCRIPTION
## Background

In order for the knowledge graph to stay consistent, `lat check` should run in the CI pipeline. In order to make that as easy as possible, I have wrapped `lat check` in a GitHub Action [`lars20070/lat-check-action`](https://github.com/lars20070/lat-check-action).

## Suggestion

Feel free to move the `lars20070/lat-check-action` repo to a new `1st1/lat-check-action` repo **before merging the this branch**. I will then delist `lars20070/lat-check-action` from the marketplace and delete my repo.

## Added
* New CI workflow which runs `lat check` as part of the GitHub Action `lars20070/lat-check-action`

## Testing
* Successfully tested in the CI pipeline of the [`pytest-assay`](https://github.com/lars20070/pytest-assay/blob/master/.github/workflows/lat-check.yaml) project