### PR TITLE
Add Google Antigravity support

### DIFF
--- a/lat.md/cli.md
+++ b/lat.md/cli.md
@@ -150,11 +150,11 @@ Steps:
 1. **lat.md/ directory** — if not present, asks whether to create it (via a one-off readline interface that is closed before step 2). Scaffolds from `templates/init/` (`.gitignore` and `README.md`). If it already exists, skips ahead.
 2. **Agent selection** — interactive checklist menu ([[src/cli/checklist-menu.ts#checklistMenu]]). All agents are shown at once with `[x]`/`[ ]` checkboxes; the cursor row is highlighted with `chalk.bgCyan`. Keys: up/down (j/k) to move, Space to toggle, Enter to confirm, Ctrl+C to abort. Returns an array of selected agent values. Non-TTY fallback returns `[]`. After confirmation, prints a summary line (e.g. "Selected: Claude Code, Cursor" or dim "None"). **Important:** the persistent readline interface is created _after_ this step — `checklistMenu` puts stdin into raw mode with its own `data` listener, which corrupts any co-existing readline interface.
 3. **Command style** — if any selected agent needs a lat command reference (all except Codex), a `selectMenu` asks "How should agents run lat?" with three options: `lat` (global install, portable), the resolved local binary path, or `npx lat.md@latest` (slow but zero-install). The choice determines what command string is written into hooks, MCP configs, and Pi extensions. Non-interactive mode defaults to `local`. Choosing `global` or `npx` makes generated config files portable and safe to commit.
-4. **AGENTS.md** — created if a non-Claude agent is selected (Cursor, Copilot, Codex). Shared instruction file. Uses marker-based append mode (see below).
+4. **AGENTS.md** — created if a non-Claude agent is selected (Cursor, Copilot, Codex, Antigravity). Shared instruction file. Uses marker-based append mode (see below).
 5. **Per-agent setup** — configures each selected agent (see subsections below). Each step prints a brief explanation of _why_ it's needed (e.g. why a hook is used instead of CLAUDE.md, why MCP is registered alongside CLI access).
 6. **LLM key setup** — checks for an existing key (env var or [[cli#Configuration File]]), and if missing, interactively prompts the user to paste one. Explains what semantic search is and why a key is needed before asking.
 7. **Version stamp + file hashes** — writes `INIT_VERSION` and SHA-256 hashes of all template-generated files to `lat.md/.cache/lat_init.json`. On re-run, compares current file content against stored hashes: unmodified files are silently updated to the latest template; user-modified files trigger a Y/n prompt offering to overwrite with the latest template, declining suggests [[cli#gen]].
-8. **Next steps** — after all setup completes, prints agent-specific guidance for having the agent document the codebase. For Claude Code, shows a runnable `claude "..."` command. For IDE agents (Cursor, Copilot, Pi, OpenCode, Codex), shows the prompt to paste into agent chat. Both suggest running `lat check` when done.
+8. **Next steps** — after all setup completes, prints agent-specific guidance for having the agent document the codebase. For Claude Code, shows a runnable `claude "..."` command. For IDE agents (Cursor, Copilot, Pi, OpenCode, Codex, Antigravity), shows the prompt to paste into agent chat. Both suggest running `lat check` when done.
 
 At the very end, after all steps complete, init checks whether ripgrep (`rg`) is available. If missing, prints a tip suggesting the user install it for faster code scanning, with a link to the ripgrep installation guide.
 
@@ -218,6 +218,16 @@ Sets up AGENTS.md, registers the MCP server, and installs skills for the Codex C
 - `.codex` directory added to `.gitignore` (config contains local absolute paths)
 - `.agents/skills/lat-md/SKILL.md` — skill spec for authoring `lat.md/` files, placed in the cross-agent standard skills directory
 - `.codex/skills/lat-md/SKILL.md` — same skill spec in Codex's native skills directory
+
+### Antigravity
+
+Sets up AGENTS.md, workspace rules, and registers the MCP server for Google's Antigravity IDE.
+
+- `AGENTS.md` — shared instruction file (created in the shared step). Antigravity uses AGENTS.md as its primary config.
+- `GEMINI.md` — legacy fallback. If the file already exists in the project root, init updates its lat section using marker-based append mode. Not created if absent.
+- `.agents/rules/lat.md` — workspace rules file generated from the AGENTS.md template, references CLI commands (not MCP tools, since Antigravity has no per-workspace MCP config). Antigravity discovers workspace rules from `.agents/rules/` and can activate them as always-on or model-decision based.
+- `.agents/skills/lat-md/SKILL.md` — skill spec for authoring `lat.md/` files, placed in the cross-agent standard skills directory (Antigravity discovers skills from `.agents/skills/`)
+- No per-workspace MCP server is registered — Antigravity does not support per-project MCP configuration (MCP is global only).
 
 All setup steps are idempotent — existing configuration is detected and skipped.
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1007,6 +1007,60 @@ async function setupOpenCode(
   ensureGitignored(root, '.opencode');
 }
 
+async function setupAntigravity(
+  root: string,
+  latDir: string,
+  hashes: Record<string, string>,
+  ask: (message: string) => Promise<boolean>,
+): Promise<void> {
+  // AGENTS.md — Antigravity reads this natively
+  // (already created in the shared step if any non-Claude agent is selected)
+
+  // AGENTS.md is the primary config — Antigravity reads it natively.
+  // GEMINI.md is a legacy fallback; update it if it already exists.
+  if (existsSync(join(root, 'GEMINI.md'))) {
+    const geminiHash = await appendTemplateSection(
+      root,
+      latDir,
+      'GEMINI.md',
+      readAgentsTemplate(),
+      'GEMINI.md',
+      '  ',
+      ask,
+    );
+    if (geminiHash) hashes['GEMINI.md'] = geminiHash;
+  }
+
+  // .agents/rules/lat.md — workspace rules (Antigravity discovers from .agents/rules/)
+  console.log('');
+  console.log(
+    styleText(
+      'dim',
+      '  Workspace rules give Antigravity the lat.md workflow checklist and',
+    ),
+  );
+  console.log(
+    styleText('dim', '  CLI commands so the agent uses lat proactively.'),
+  );
+
+  const rulesHash = await writeTemplateFile(
+    root,
+    latDir,
+    '.agents/rules/lat.md',
+    readAgentsTemplate(),
+    'agents.md',
+    'Rules (.agents/rules/lat.md)',
+    '  ',
+    ask,
+  );
+  if (rulesHash) hashes['.agents/rules/lat.md'] = rulesHash;
+
+  // Antigravity does not support per-workspace MCP config — MCP is global only.
+
+  // .agents/skills/lat-md/SKILL.md — skill for authoring lat.md files
+  await writeAgentsSkill(root, latDir, hashes, ask);
+}
+
 async function setupCodex(
   root: string,
   latDir: string,
@@ -1196,6 +1250,7 @@ function printNextSteps(selectedAgents: string[]): void {
     pi: 'Pi',
     opencode: 'OpenCode',
     codex: 'Codex',
+    antigravity: 'Antigravity',
   };
 
   if (!hasClaudeCode && ideAgents.length === 0) return;
@@ -1304,6 +1359,7 @@ export async function initCmd(targetDir?: string): Promise<void> {
       { label: 'VS Code Copilot', value: 'copilot' },
       { label: 'OpenCode', value: 'opencode' },
       { label: 'Codex', value: 'codex' },
+      { label: 'Antigravity', value: 'antigravity' },
     ];
 
     const selectedAgents = await checklistMenu(
@@ -1317,6 +1373,7 @@ export async function initCmd(targetDir?: string): Promise<void> {
     const useCopilot = selectedAgents.includes('copilot');
     const useOpenCode = selectedAgents.includes('opencode');
     const useCodex = selectedAgents.includes('codex');
+    const useAntigravity = selectedAgents.includes('antigravity');
 
     const anySelected = selectedAgents.length > 0;
     const needsLatCommand =
@@ -1374,7 +1431,12 @@ export async function initCmd(targetDir?: string): Promise<void> {
 
     // Step 3: AGENTS.md (shared by non-Claude agents)
     const needsAgentsMd =
-      usePi || useCursor || useCopilot || useOpenCode || useCodex;
+      usePi ||
+      useCursor ||
+      useCopilot ||
+      useOpenCode ||
+      useCodex ||
+      useAntigravity;
     if (needsAgentsMd) {
       await setupAgentsMd(root, latDir, template, fileHashes, ask);
     }
@@ -1421,6 +1483,12 @@ export async function initCmd(targetDir?: string): Promise<void> {
       console.log('');
       console.log(styleText('bold', 'Setting up Codex...'));
       await setupCodex(root, latDir, fileHashes, ask, commandStyle);
+    }
+
+    if (useAntigravity) {
+      console.log('');
+      console.log(styleText('bold', 'Setting up Antigravity...'));
+      await setupAntigravity(root, latDir, fileHashes, ask);
     }
 
     // Step 5: LLM key setup


### PR DESCRIPTION
# Add Google Antigravity support to `lat init`

## Summary

- Add Google Antigravity as a supported agent in `lat init`
- Antigravity uses `AGENTS.md` as its primary config (shared with other non-Claude agents)
- Writes workspace rules to `.agents/rules/lat.md` with CLI command references
- Installs the lat-md authoring skill at `.agents/skills/lat-md/SKILL.md`
- Updates legacy `GEMINI.md` if it already exists (not created from scratch)
- No per-workspace MCP server — Antigravity only supports global MCP config

## What gets created

| File | Purpose |
|------|---------|
| `AGENTS.md` | Shared lat.md instructions (CLI commands) |
| `.agents/rules/lat.md` | Workspace rules for agent discovery |
| `.agents/skills/lat-md/SKILL.md` | Authoring guide for lat.md files |

## Design decisions

- **No MCP setup**: Antigravity doesn't support per-project MCP configuration, so all tool access is via CLI commands (`lat search`, `lat check`, etc.)
- **No GEMINI.md creation**: Antigravity is migrating from `GEMINI.md` to `AGENTS.md`. Legacy `GEMINI.md` is updated if present, not created fresh.
- **Rules use AGENTS.md template** (not cursor-rules): Since there's no MCP server, rules reference CLI commands instead of MCP tools.
- **No command style needed**: Without MCP or hooks, the binary path style choice doesn't apply.

## Test plan

- [ ] Run `lat init`, select Antigravity — verify `AGENTS.md`, `.agents/rules/lat.md`, `.agents/skills/lat-md/SKILL.md` are created
- [ ] Run `lat init` in a project with existing `GEMINI.md` — verify it gets updated with markers
- [ ] Run `lat init` in a project without `GEMINI.md` — verify it's not created
- [ ] Run `lat check` — all checks pass
- [ ] `npx tsc --noEmit` passes
