### PR TITLE
feat: add Ruby language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Then run `lat init` in the repo you want to use lat in.
 
 ## How it works
 
-Run `lat init` to scaffold a `lat.md/` directory, then write markdown files describing your architecture, business logic, test specs — whatever matters. Link between sections using `[[file#Section#Subsection]]` syntax. Link to source code symbols with `[[src/auth.ts#validateToken]]`. Annotate source code with `// @lat: [[section-id]]` (or `# @lat: [[section-id]]` in Python) comments to tie implementation back to concepts.
+Run `lat init` to scaffold a `lat.md/` directory, then write markdown files describing your architecture, business logic, test specs — whatever matters. Link between sections using `[[file#Section#Subsection]]` syntax. Link to source code symbols with `[[src/auth.ts#validateToken]]`. Annotate source code with `// @lat: [[section-id]]` (or `# @lat: [[section-id]]` in Python/Ruby) comments to tie implementation back to concepts.
 
 ```
 my-project/

--- a/lat.md/markdown.md
+++ b/lat.md/markdown.md
@@ -32,7 +32,7 @@ Resolution is handled by [[src/lattice.ts#resolveRef]]. See [[parser#Short Ref R
 
 ### Source Code Links
 
-Wiki links can reference symbols in TypeScript, JavaScript, Python, Rust, Go, and C source files:
+Wiki links can reference symbols in TypeScript, JavaScript, Python, Ruby, Rust, Go, and C source files:
 
 - **`[[src/config.ts#getConfigDir]]`** — the `getConfigDir` function in `src/config.ts`
 - **`[[src/server.ts#App#listen]]`** — the `listen` method on class `App` in `src/server.ts`
@@ -42,13 +42,15 @@ Wiki links can reference symbols in TypeScript, JavaScript, Python, Rust, Go, an
 - **`[[src/app.h#Greeter#prefix]]`** — the `prefix` field of struct `Greeter` in C
 - **`[[src/config.ts]]`** — link to the file itself (no symbol)
 
-Supported extensions: `.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.rs`, `.go`, `.c`, `.h`.
+Supported extensions: `.ts`, `.tsx`, `.js`, `.jsx`, `.py`, `.rb`, `.rs`, `.go`, `.c`, `.h`.
 
 Python symbols: functions, classes, methods, module-level variables. Decorated definitions (`@decorator`) are unwrapped transparently — `[[file.py#my_func]]` resolves whether or not `my_func` has decorators, and `# @lat:` comments placed between decorators and the `def`/`class` line are scanned normally.
 
 Rust symbols: functions, structs, enums, traits, impl methods, consts, statics, type aliases. Methods are resolved via `impl` blocks — `[[file.rs#Type#method]]` matches any `impl Type { fn method() }` or `impl Trait for Type { fn method() }`.
 
 Go symbols: functions, types (structs, interfaces, type aliases), methods (with receiver), consts, vars. Methods are resolved via receiver type — `[[file.go#Type#Method]]` matches `func (t *Type) Method()`.
+
+Ruby symbols: methods (def), classes, modules, singleton methods (def self.foo), constants. Methods inside classes/modules are resolved via the parent — `[[file.rb#Greeter#greet]]` matches `def greet` inside `class Greeter`. `# @lat:` comments are supported for code refs.
 
 C symbols: functions (including pointer-returning like `char *func()`), structs, struct fields/members, enums, enum values (including anonymous enums and `typedef enum` members), typedefs, `#define` macros (both object-like and function-like), variables (including arrays). Struct fields are resolved via the parent struct — `[[file.h#Struct#field]]` matches any `field_declaration` inside `struct Struct { ... }`, including fields nested inside anonymous unions and structs. Enum values can be referenced standalone (`[[file.h#GREEN]]`) or qualified by their enum name (`[[file.h#Color#GREEN]]`); both forms work for named enums, `typedef enum`, and named `typedef enum`. Both `.c` and `.h` files are supported — include guards (`#ifndef`/`#endif`) are walked through transparently.
 

--- a/src/source-parser.ts
+++ b/src/source-parser.ts
@@ -60,6 +60,7 @@ const grammarMap: Record<string, string> = {
   '.go': 'tree-sitter-go.wasm',
   '.c': 'tree-sitter-c.wasm',
   '.h': 'tree-sitter-c.wasm',
+  '.rb': 'tree-sitter-ruby.wasm',
 };
 
 /** All source file extensions that lat can parse (derived from grammarMap). */
@@ -517,6 +518,119 @@ function extractGoSymbols(tree: Tree): SourceSymbol[] {
   return symbols;
 }
 
+function extractRubySymbols(tree: Tree): SourceSymbol[] {
+  const symbols: SourceSymbol[] = [];
+  const root = tree.rootNode;
+
+  for (let i = 0; i < root.childCount; i++) {
+    const node = root.child(i)!;
+    const startLine = node.startPosition.row + 1;
+    const endLine = node.endPosition.row + 1;
+
+    if (node.type === 'method') {
+      const name = node.childForFieldName('name')?.text;
+      if (name) {
+        symbols.push({
+          name,
+          kind: 'function',
+          startLine,
+          endLine,
+          signature: firstLine(node.text),
+        });
+      }
+    } else if (node.type === 'singleton_method') {
+      const name = node.childForFieldName('name')?.text;
+      if (name) {
+        symbols.push({
+          name,
+          kind: 'function',
+          startLine,
+          endLine,
+          signature: firstLine(node.text),
+        });
+      }
+    } else if (node.type === 'class') {
+      const name = node.childForFieldName('name')?.text;
+      if (name) {
+        symbols.push({
+          name,
+          kind: 'class',
+          startLine,
+          endLine,
+          signature: firstLine(node.text),
+        });
+        const body = node.childForFieldName('body');
+        if (body) {
+          extractRubyMethods(body, name, symbols);
+        }
+      }
+    } else if (node.type === 'module') {
+      const name = node.childForFieldName('name')?.text;
+      if (name) {
+        symbols.push({
+          name,
+          kind: 'class',
+          startLine,
+          endLine,
+          signature: firstLine(node.text),
+        });
+        const body = node.childForFieldName('body');
+        if (body) {
+          extractRubyMethods(body, name, symbols);
+        }
+      }
+    } else if (node.type === 'assignment') {
+      const left = node.childForFieldName('left');
+      if (left && left.type === 'constant') {
+        symbols.push({
+          name: left.text,
+          kind: 'const',
+          startLine,
+          endLine,
+          signature: firstLine(node.text),
+        });
+      }
+    }
+  }
+
+  return symbols;
+}
+
+function extractRubyMethods(
+  body: SyntaxNode,
+  className: string,
+  symbols: SourceSymbol[],
+): void {
+  for (let i = 0; i < body.namedChildCount; i++) {
+    const member = body.namedChild(i)!;
+    if (member.type === 'method') {
+      const name = member.childForFieldName('name')?.text;
+      if (name) {
+        symbols.push({
+          name,
+          kind: 'method',
+          parent: className,
+          startLine: member.startPosition.row + 1,
+          endLine: member.endPosition.row + 1,
+          signature: firstLine(member.text),
+        });
+      }
+    } else if (member.type === 'singleton_method') {
+      const name = member.childForFieldName('name')?.text;
+      if (name) {
+        symbols.push({
+          name,
+          kind: 'method',
+          parent: className,
+          startLine: member.startPosition.row + 1,
+          endLine: member.endPosition.row + 1,
+          signature: firstLine(member.text),
+        });
+      }
+    }
+  }
+}
+
 /**
  * Extract the declarator name from a C function_declarator node.
  * Handles plain identifiers and pointer declarators (*name).
@@ -861,6 +975,9 @@ export async function parseSourceSymbols(
     }
     if (ext === '.c' || ext === '.h') {
       return extractCSymbols(tree);
+    }
+    if (ext === '.rb') {
+      return extractRubySymbols(tree);
     }
     return extractTsSymbols(tree);
   } finally {

--- a/tests/cases.test.ts
+++ b/tests/cases.test.ts
@@ -846,6 +846,43 @@ describe('source-ref-go-valid', () => {
   });
 });
 
+describe('source-ref-rb-valid', () => {
+  it('resolves Ruby function, class, module, method, singleton method, and constant refs without errors', async () => {
+    // docs.md links: greet (function), Greeter (class), Greeter#greet (method),
+    // Greeter#create (singleton method), Helpers (module), Helpers#assist (method),
+    // DEFAULT_NAME (constant)
+    const { errors } = await checkMd(latDir('source-ref-rb-valid'));
+    expect(errors).toHaveLength(0);
+  });
+});
+
+describe('error-source-ref-rb-missing', () => {
+  it('check md reports all missing Ruby symbols', async () => {
+    const { errors } = await checkMd(latDir('error-source-ref-rb-missing'));
+    expect(errors).toHaveLength(4);
+
+    const byTarget = new Map(errors.map((e) => [e.target, e]));
+
+    const fn = byTarget.get('src/app.rb#nonexistent')!;
+    expect(fn).toBeDefined();
+    expect(fn.message).toContain('symbol "nonexistent" not found');
+
+    const cls = byTarget.get('src/app.rb#MissingClass')!;
+    expect(cls).toBeDefined();
+    expect(cls.message).toContain('symbol "MissingClass" not found');
+
+    const cnst = byTarget.get('src/app.rb#MISSING_CONST')!;
+    expect(cnst).toBeDefined();
+    expect(cnst.message).toContain('symbol "MISSING_CONST" not found');
+
+    const method = byTarget.get('src/app.rb#Greeter#missing_method')!;
+    expect(method).toBeDefined();
+    expect(method.message).toContain(
+      'symbol "Greeter#missing_method" not found',
+    );
+  });
+});
+
 describe('error-source-ref-rs-missing', () => {
   it('check md reports all missing Rust symbols', async () => {
     const { errors } = await checkMd(latDir('error-source-ref-rs-missing'));

--- a/tests/cases/error-source-ref-rb-missing/lat.md/docs.md
+++ b/tests/cases/error-source-ref-rb-missing/lat.md/docs.md
@@ -1,0 +1,9 @@
+# Docs
+
+Missing function: [[src/app.rb#nonexistent]].
+
+Missing class: [[src/app.rb#MissingClass]].
+
+Missing constant: [[src/app.rb#MISSING_CONST]].
+
+Missing method: [[src/app.rb#Greeter#missing_method]].

--- a/tests/cases/error-source-ref-rb-missing/src/app.rb
+++ b/tests/cases/error-source-ref-rb-missing/src/app.rb
@@ -1,0 +1,9 @@
+def greet(name)
+  "Hello, #{name}!"
+end
+
+class Greeter
+  def greet(name)
+    "Hi, #{name}!"
+  end
+end

--- a/tests/cases/source-ref-rb-valid/lat.md/docs.md
+++ b/tests/cases/source-ref-rb-valid/lat.md/docs.md
@@ -1,0 +1,11 @@
+# Docs
+
+See [[src/app.rb#greet]] for the greeting function.
+
+The [[src/app.rb#Greeter]] class has a method [[src/app.rb#Greeter#greet]].
+
+Singleton method: [[src/app.rb#Greeter#create]].
+
+Module: [[src/app.rb#Helpers]] with [[src/app.rb#Helpers#assist]].
+
+Default name is [[src/app.rb#DEFAULT_NAME]].

--- a/tests/cases/source-ref-rb-valid/src/app.rb
+++ b/tests/cases/source-ref-rb-valid/src/app.rb
@@ -1,0 +1,21 @@
+def greet(name)
+  "Hello, #{name}!"
+end
+
+class Greeter
+  def greet(name)
+    "Hi, #{name}!"
+  end
+
+  def self.create(name)
+    new(name)
+  end
+end
+
+module Helpers
+  def assist(name)
+    "Helping #{name}!"
+  end
+end
+
+DEFAULT_NAME = "World"


### PR DESCRIPTION
## Summary

- Adds `.rb` extension to the source parser grammar map (tree-sitter-ruby WASM is already bundled in `@repomix/tree-sitter-wasms`)
- Implements `extractRubySymbols` supporting: top-level methods, classes, modules, singleton methods (`def self.foo`), instance methods, and constants
- `# @lat: [[section-id]]` comment syntax works out of the box (already handled by `LAT_REF_RE`)
- Adds test cases for valid resolution and missing symbol error reporting

## Motivation

We have a legacy codebase in Ruby and need `lat` to understand our `.rb` files — resolving wiki links like `[[src/app.rb#MyClass#my_method]]` and scanning `# @lat:` code refs.

## Test plan

- [x] `source-ref-rb-valid` — resolves function, class, module, method, singleton method, and constant refs
- [x] `error-source-ref-rb-missing` — reports missing symbols with correct error messages
- [x] All existing source-ref tests still pass (16/16)
- [x] `lat check` passes on the project itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)