### PR TITLE
feat(provider): Ollama/local provider + LAT_LLM_BASE_URL/MODEL env overrides

### DIFF
--- a/src/search/provider.ts
+++ b/src/search/provider.ts
@@ -28,6 +28,17 @@ const vercel: EmbeddingProvider = {
   }),
 };
 
+function applyEnvOverrides(provider: EmbeddingProvider): EmbeddingProvider {
+  const baseUrl = process.env.LAT_LLM_BASE_URL;
+  const model = process.env.LAT_LLM_MODEL;
+  if (!baseUrl && !model) return provider;
+  return {
+    ...provider,
+    ...(baseUrl ? { apiBase: baseUrl } : {}),
+    ...(model ? { model } : {}),
+  };
+}
+
 export function detectProvider(key: string): EmbeddingProvider {
   if (key.startsWith('REPLAY_LAT_LLM_KEY::')) {
     const replayUrl = key.slice('REPLAY_LAT_LLM_KEY::'.length);
@@ -44,9 +55,19 @@ export function detectProvider(key: string): EmbeddingProvider {
       "Anthropic doesn't offer an embedding model. Set LAT_LLM_KEY to an OpenAI (sk-...) or Vercel AI Gateway (vck_...) key.",
     );
   }
-  if (key.startsWith('vck_')) return vercel;
-  if (key.startsWith('sk-')) return openai;
+  if (key.startsWith('vck_')) return applyEnvOverrides(vercel);
+  if (key.startsWith('sk-')) return applyEnvOverrides(openai);
+  // Ollama and other local OpenAI-compatible providers (no auth required)
+  if (key === 'ollama' || key === 'local') {
+    return {
+      name: 'ollama',
+      apiBase: process.env.LAT_LLM_BASE_URL ?? 'http://localhost:11434/v1',
+      model: process.env.LAT_LLM_MODEL ?? 'nomic-embed-text',
+      dimensions: 768,
+      headers: () => ({ 'Content-Type': 'application/json' }),
+    };
+  }
   throw new Error(
-    `Unrecognized LAT_LLM_KEY prefix. Supported: OpenAI (sk-...), Vercel AI Gateway (vck_...).`,
+    `Unrecognized LAT_LLM_KEY prefix. Supported: OpenAI (sk-...), Vercel AI Gateway (vck_...), Ollama (ollama).`,
   );
 }


### PR DESCRIPTION
## Summary

- **`LAT_LLM_KEY=ollama`** — connects to Ollama at `http://localhost:11434/v1` using `nomic-embed-text` (768-dim). No API key needed.
- **`LAT_LLM_KEY=local`** — alias for `ollama`.
- **`LAT_LLM_BASE_URL`** — overrides `apiBase` for _any_ provider (openai, vercel, ollama). Useful for self-hosted OpenAI-compatible endpoints.
- **`LAT_LLM_MODEL`** — overrides the embedding model name for any provider.

## Motivation

Users running local LLM stacks (Ollama, LM Studio, vLLM, etc.) currently have no way to use `lat search` without an OpenAI or Vercel API key. The `REPLAY_LAT_LLM_KEY::URL` workaround hardcodes `model: 'replay'` which most local servers reject.

## Usage

```bash
# Ollama (fully local, no API key)
export LAT_LLM_KEY=ollama
ollama pull nomic-embed-text
lat search "architecture overview"

# Custom OpenAI-compatible endpoint
export LAT_LLM_KEY="sk-..."
export LAT_LLM_BASE_URL="https://my-proxy/v1"
export LAT_LLM_MODEL="text-embedding-ada-002"
lat search "authentication flow"
```

## Test plan

- [ ] `LAT_LLM_KEY=ollama` resolves to `http://localhost:11434/v1` + `nomic-embed-text`
- [ ] `LAT_LLM_BASE_URL` overrides apiBase for openai provider
- [ ] `LAT_LLM_MODEL` overrides model for vercel provider
- [ ] Existing `sk-` / `vck_` / `REPLAY_LAT_LLM_KEY::` paths unchanged
- [ ] Error message updated to mention `ollama`

🤖 Generated with [Claude Code](https://claude.com/claude-code)