### PR TITLE
Batch embeddings by token budget, not just input count

### DIFF
--- a/lat.md/cli.md
+++ b/lat.md/cli.md
@@ -328,7 +328,9 @@ Implementation: [[src/search/provider.ts]], [[src/config.ts]]
 
 ### Embeddings
 
-Direct `fetch()` calls to the provider's OpenAI-compatible `/v1/embeddings` endpoint. No LangChain or other framework — keeps the dependency tree minimal. Batches up to 2048 texts per request.
+Direct `fetch()` calls to the provider's OpenAI-compatible `/v1/embeddings` endpoint. No LangChain or other framework — keeps the dependency tree minimal.
+
+[[src/search/embeddings.ts#planBatches]] splits inputs into requests bounded by both count (2048 texts) and estimated tokens (~250k, under the API's 300k-tokens-per-request cap), so a large corpus indexes without a `max_tokens_per_request` error.
 
 Implementation: [[src/search/embeddings.ts]]
 

--- a/src/search/embeddings.ts
+++ b/src/search/embeddings.ts
@@ -1,6 +1,40 @@
 import type { EmbeddingProvider } from './provider.js';
 
+// Max inputs per request — the embedding APIs also cap array length.
 const MAX_BATCH = 2048;
+// Stay comfortably under the embedding APIs' 300k-tokens-per-request cap.
+const MAX_BATCH_TOKENS = 250_000;
+
+// Rough token estimate: ~4 chars/token for English prose + code.
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+// Split texts into batches bounded by BOTH input count and estimated tokens,
+// so a large corpus doesn't exceed the per-request token limit. Order is
+// preserved, so callers can map results back positionally.
+export function planBatches(texts: string[]): string[][] {
+  const batches: string[][] = [];
+  let batch: string[] = [];
+  let batchTokens = 0;
+
+  for (const text of texts) {
+    const tokens = estimateTokens(text);
+    if (
+      batch.length > 0 &&
+      (batch.length >= MAX_BATCH || batchTokens + tokens > MAX_BATCH_TOKENS)
+    ) {
+      batches.push(batch);
+      batch = [];
+      batchTokens = 0;
+    }
+    batch.push(text);
+    batchTokens += tokens;
+  }
+  if (batch.length > 0) batches.push(batch);
+
+  return batches;
+}
 
 export async function embed(
   texts: string[],
@@ -9,8 +43,7 @@ export async function embed(
 ): Promise<number[][]> {
   const results: number[][] = [];
 
-  for (let i = 0; i < texts.length; i += MAX_BATCH) {
-    const batch = texts.slice(i, i + MAX_BATCH);
+  for (const batch of planBatches(texts)) {
     const resp = await fetch(`${provider.apiBase}/embeddings`, {
       method: 'POST',
       headers: provider.headers(key),

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -6,6 +6,7 @@ import {
   detectProvider,
   type EmbeddingProvider,
 } from '../src/search/provider.js';
+import { planBatches } from '../src/search/embeddings.js';
 import { openDb, ensureSchema, closeDb } from '../src/search/db.js';
 import { indexSections } from '../src/search/index.js';
 import { searchSections } from '../src/search/search.js';
@@ -33,6 +34,33 @@ describe('detectProvider', () => {
 
   it('rejects unknown key', () => {
     expect(() => detectProvider('xyz_abc123')).toThrow(/Unrecognized/);
+  });
+});
+
+// @lat: [[cli#Embeddings]]
+describe('planBatches', () => {
+  it('keeps a small corpus in a single batch', () => {
+    const batches = planBatches(['a', 'b', 'c']);
+    expect(batches).toEqual([['a', 'b', 'c']]);
+  });
+
+  it('splits when the estimated token budget is exceeded', () => {
+    // ~4 chars/token, 250k-token cap → ~1M chars per batch.
+    const big = 'x'.repeat(600_000); // ~150k tokens each
+    const batches = planBatches([big, big, big]);
+    expect(batches.map((b) => b.length)).toEqual([1, 1, 1]);
+  });
+
+  it('never emits an empty batch', () => {
+    expect(planBatches([])).toEqual([]);
+    expect(planBatches(['only']).every((b) => b.length > 0)).toBe(true);
+  });
+
+  it('preserves order and loses no inputs', () => {
+    const texts = Array.from({ length: 5000 }, (_, i) => `text-${i}`);
+    const batches = planBatches(texts);
+    expect(batches.length).toBeGreaterThan(1); // > 2048 count cap
+    expect(batches.flat()).toEqual(texts);
   });
 });
 


### PR DESCRIPTION
## Problem

Indexing a large corpus dies with:

```
Embedding API error (400): Requested 375703 tokens, max 300000 tokens per request (max_tokens_per_request)
```

`embed()` batched inputs only by count (`MAX_BATCH = 2048`), but the OpenAI-compatible `/v1/embeddings` endpoint caps each request by **tokens** (300k). Once the changed-section set embeds to more than ~300k tokens in a single array, every request 400s and the index never builds — there's no partial write, so `lat search` stays broken.

## Fix

Add `planBatches()`, which splits inputs into requests bounded by **both** input count (2048) and estimated tokens (~250k, comfortably under the 300k cap; a ~4-chars/token estimate, no tokenizer dependency added). Order is preserved, so `embed()` still maps returned vectors back to inputs positionally. `embed()` now iterates `planBatches(texts)` instead of a fixed-stride slice.

## Tests

New always-run `planBatches` unit tests (no API/replay needed): single small batch, token-budget split, no empty batches, and order/no-loss across the 2048 count cap. `typecheck` clean; `tests/search.test.ts` 13/13 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)