### PR TITLE
Release 0.12.0 — offline-first local embeddings

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,16 @@ lat mcp                         # start MCP server for editor integration
 
 ## Configuration
 
-Semantic search (`lat search`) requires an OpenAI (`sk-...`) or Vercel AI Gateway (`vck_...`) API key. The key is resolved in order:
+Semantic search (`lat search`) works **offline by default** — no API key required. It uses a bundled local embedding model (all-MiniLM-L6-v2, compiled to WebAssembly; no native binaries, no network).
+
+To use higher-quality hosted embeddings instead, provide an OpenAI (`sk-...`) or Vercel AI Gateway (`vck_...`) API key, resolved in order:
 
 1. `LAT_LLM_KEY` env var — direct value
 2. `LAT_LLM_KEY_FILE` env var — path to a file containing the key
 3. `LAT_LLM_KEY_HELPER` env var — shell command that prints the key (10s timeout)
 4. Config file — saved by `lat init`. Run `lat config` to see its location.
+
+Switch backends any time with `lat reindex` (`--local` to force the offline model, `--remote` to use your key).
 
 ## Development
 

--- a/lat.md/dev-process.md
+++ b/lat.md/dev-process.md
@@ -49,7 +49,11 @@ Prettier with no semicolons, single quotes, trailing commas. Run `pnpm format` b
 
 ## Publishing
 
-Published to npm as `lat.md`. The `bin` entry exposes the `lat` command. Only `dist/src` is included in the package — tests and the [[website]] are excluded.
+A pnpm workspace publishing **three** npm packages: the root `lat.md` CLI and two supporting packages it depends on — `@lat.md/embed` (embedding engine) and `@lat.md/embed-minilm-fp16` (bundled local weights).
+
+The `bin` entry exposes the `lat` command. Only `dist/src` and `templates` are included in the root package — tests and the [[website]] are excluded; the embed packages each ship their own `dist`.
+
+The two `@lat.md/*` packages are runtime `dependencies` of the root, declared as `workspace:*`. `pnpm publish` rewrites `workspace:*` to the exact local version at publish time, so a released `lat.md` pins the embed packages by their real published versions.
 
 ### Release Process
 
@@ -58,22 +62,20 @@ Step-by-step procedure for cutting a release: version bump, changelog, PR, and n
 1. **Compile changelog** — run `git log --oneline` since the last version bump commit (look for commits matching `Bump to X.Y.Z`) and summarize notable changes as bullet points. Only include user-facing features, fixes, and behavioral changes — skip doc-only updates, refactors, and other commits that don't affect functionality
 2. **Sync main** — `git fetch` and rebase/merge to ensure local `main` is up to date with the remote before branching
 3. **Create a release branch** — branch off `main`, e.g. `release/0.1.5`
-4. **Bump version** — update `version` in `package.json`. Commit message: `Bump to X.Y.Z`
+4. **Bump versions** — update `version` in the root `package.json`. **Also bump any `@lat.md/*` workspace package whose source changed since its last publish** (compare `npm view <pkg> version` against the local `version`; inspect the published tarball if unsure). The [[dev-process#Publishing#Publish Workflow]] only republishes a package whose version is not already on npm, so a changed-but-unbumped package would silently ship stale to users while the root pins the old version. Commit message: `Bump to X.Y.Z`
 5. **Switch back to main** — check out `main` so the working tree is not left on the release branch
 6. **Push main and open a PR** — push `main` first (so the release branch diff is clean), then push the release branch and create a PR with the changelog as the body
 7. **Merge** — once CI passes and the PR is merged to `main`, the [[dev-process#Publishing#Publish Workflow]] takes over
 
-Version numbers follow semver. While pre-1.0, bump the patch for fixes and the minor for features/breaking changes.
+Version numbers follow semver. While pre-1.0, bump the patch for fixes and the minor for features/breaking changes. Each `@lat.md/*` package is versioned independently under the same rule.
 
 ### Publish Workflow
 
 GitHub Actions workflow at `.github/workflows/publish.yml`. Runs on every push to `main`:
 
-1. **Detect version change** — compares `version` in `package.json` against the previous commit. If unchanged, skips all publish steps
-2. **Install ripgrep** — `apt-get install ripgrep` so both rg and TS-fallback code paths are exercised
-3. **Run tests** — `pnpm install`, `pnpm build`, `pnpm vitest run`
-3. **Publish to npm** — `pnpm publish --no-git-checks` using the `NPM_TOKEN` repository secret
-4. **Create GitHub release** — tags `vX.Y.Z` and creates a GitHub release with auto-generated notes
+1. **Set up the toolchain** — Node 22 + pnpm, a Rust toolchain with the `wasm32-unknown-unknown` target, and `wasm-bindgen-cli` pinned to the `Cargo.lock` version (`0.2.126`), needed to build the `@lat.md/embed` WASM engine. Also installs ripgrep (`apt-get install ripgrep`) so both the rg and TS-fallback code paths are exercised
+2. **Build and test** — `pnpm install --frozen-lockfile`, then `pnpm buildall` (builds the WASM engine + fp16 weights + the top-level `lat` via `tsc`), then `pnpm vitest run`
+3. **Publish changed packages** — a `publish_if_new` shell helper publishes each package **in dependency order** (`packages/embed-minilm-fp16` → `packages/embed` → root `.`), skipping any whose `version` is already on npm (checked via `npm view <name>@<version>`). Each publishes with `pnpm publish --provenance --access public --no-git-checks`. Because `workspace:*` is rewritten at publish time, publishing the leaf packages first guarantees the root's rewritten pins already resolve on npm
+4. **Create GitHub release** — if a `vX.Y.Z` tag/release for the root version does not yet exist, creates one with auto-generated notes
 
-Uses npm trusted publishing (OIDC) — no secrets needed. The `--provenance` flag signs and publishes the package using the GitHub Actions identity. The `lat.md` package is linked to the `1st1/lat.md` repo on npmjs.com under Settings → Publishing Access.
- using the GitHub Actions identity. The `lat.md` package is linked to the `1st1/lat.md` repo on npmjs.com under Settings → Publishing Access.
+Uses npm trusted publishing (OIDC) — no `NPM_TOKEN` secret needed. The `--provenance` flag signs each package using the GitHub Actions identity. Each package is linked to the `1st1/lat.md` repo on npmjs.com under Settings → Publishing Access.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lat.md",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "A knowledge graph for your codebase, written in markdown",
   "type": "module",
   "packageManager": "pnpm@10.30.2",

--- a/packages/embed/package.json
+++ b/packages/embed/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lat.md/embed",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Embedding generation for lat.md — local candle/WASM MiniLM engine and OpenAI-compatible remote backends behind one interface",
   "type": "module",
   "license": "MIT",

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -172,6 +172,7 @@ export default function Home() {
             }}
           >
             {[
+              { v: '0.12', text: <>Offline semantic search — <Cmd>lat search</Cmd> works with no API key via a bundled local WASM embedding model; new <Cmd>lat reindex</Cmd> command to rebuild the index and switch backends</> },
               { v: '0.11', text: <><Cmd>lat init</Cmd> supports Codex, OpenCode, and Cursor stop hook</> },
               { v: '0.10', text: <><Cmd>lat section</Cmd> and <Cmd>lat refs</Cmd> show source code snippets; ripgrep-powered code scanning</> },
               { v: '0.9', text: <><Cmd>lat init</Cmd> creates a lat skill for supported agents</> },


### PR DESCRIPTION
## lat.md 0.12.0

Headline: **`lat search` now works fully offline, with no API key.**

### Features
- **Offline-first semantic search.** `lat search` uses a bundled local embedding model (all-MiniLM-L6-v2) compiled to WebAssembly by default — pure WASM, no native binaries, no network. Hosted OpenAI (`sk-…`) / Vercel AI Gateway (`vck_…`) backends remain available via `LAT_LLM_KEY`.
- **New `lat reindex` command.** Rebuilds the embedding index and switches backends: `--local` (force the offline model), `--remote` (use your key), `--yes` (non-interactive). Replaces the old `lat search --reindex`.
- **Index-authoritative, durable backend selection.** The backend is governed by the index plus a per-repo preference; switching to local persists across runs, and a model/dimension mismatch never silently rebuilds — you re-decide explicitly via `lat reindex`.
- Local embedding is parallelized across worker threads (one engine per CPU); `lat reindex` shows a live progress spinner on interactive terminals.

### Fixes & hardening
- Harden index rebuild against legacy caches, worker crashes, and malformed keys; fix a reindex crash on a bad key.
- The prompt hook is now read-only.
- Improve `lat init` onboarding UX.
- Drop `wasm-opt` from the WASM build (fixes a `WebAssembly.Table.grow` CI failure).

### Packaging
- **`@lat.md/embed` → 0.2.0.** The hand-published `0.1.0` predated the worker-thread parallelism and the drop-wasm-opt build fix, so it must be republished — otherwise `publish_if_new` skips it and `lat.md@0.12.0` would ship a stale, previously-crashing engine. `@lat.md/embed-minilm-fp16` stays at `0.1.0` (unchanged).
- On merge, the publish workflow publishes `@lat.md/embed@0.2.0` then `lat.md@0.12.0` (weights `0.1.0` already on npm → skipped).

### Docs
- README updated to "offline by default"; hosted key now optional.
- Website changelog: `0.12` entry.
- `lat.md/dev-process.md` Publish Workflow synced to the actual three-package, dependency-ordered flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)