### PR TITLE
Fix Windows path-separator bug in bare-name lookups (#69) + add Windows CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Normalize line endings to LF in the working tree on every platform. Without
+# this, Windows checkouts (autocrlf=true on GitHub runners) would rewrite text
+# files to CRLF and break line-based parsing and the markdown roundtrip tests.
+* text=auto eol=lf
+
+# Binary assets — never apply text/eol conversion.
+*.png binary
+*.jpg binary
+*.ico binary
+*.wasm binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,13 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    # Run the full suite on Linux and Windows so platform-specific issues
+    # (path separators, line endings) are caught before release.
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -35,7 +41,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: packages/embed-minilm-fp16/model
-          key: minilm-weights-${{ hashFiles('packages/embed-minilm-fp16/scripts/build-weights.mjs') }}
+          key: minilm-weights-${{ matrix.os }}-${{ hashFiles('packages/embed-minilm-fp16/scripts/build-weights.mjs') }}
 
       - run: pnpm install --frozen-lockfile
 

--- a/lat.md/dev-process.md
+++ b/lat.md/dev-process.md
@@ -31,6 +31,12 @@ Commands for running the test suite.
 
 Every test run includes a full `tsc --noEmit` pass over the entire codebase. If it doesn't typecheck, it doesn't pass.
 
+### Continuous Integration
+
+CI (`.github/workflows/ci.yml`) runs the full `pnpm buildall` + `vitest` suite on a `[ubuntu-latest, windows-latest]` matrix (`fail-fast: false`) so platform-specific regressions — path separators (see [[parser#Short Ref Resolution]]) and line endings — are caught before release.
+
+Cross-platform correctness relies on two conventions: stored paths are always POSIX ([[src/walk.ts#toPosix]]), and a repo-root `.gitattributes` (`eol=lf`) keeps Windows checkouts from rewriting line endings and breaking the markdown roundtrip. Tests that hold the libsql index open (`lat.md/.cache/vectors.db`) or spawn a fake `git` must clean up temp dirs with `rmSync` retries, since Windows refuses to unlink open/locked files.
+
 ## File Walking
 
 All directory walking goes through [[src/walk.ts#walkEntries]], the single entry point with `.gitignore` support that filters out `.git/` and dotfiles.

--- a/lat.md/parser.md
+++ b/lat.md/parser.md
@@ -38,6 +38,8 @@ The root (h1) heading can be omitted in references: `[[backend#CORS]]` resolves 
 
 The file index ([[src/lattice.ts#buildFileIndex]]) maps all trailing path suffixes to their full paths. For `lat.md/guides/setup`, both `guides/setup` and `setup` are indexed. All keys are lowercase for case-insensitive lookup.
 
+Stored paths are always forward-slash (POSIX), independent of host OS. Node's `path.relative()` emits the native separator (`\` on Windows), so every OS-relative path is normalized through [[src/walk.ts#toPosix]] at construction — in [[src/lattice.ts#parseSections]], [[src/lattice.ts#extractRefs]], and the code-ref scanner ([[src/code-refs.ts#scanCodeRefs]]). Without this, `buildFileIndex` (which splits on `/`) failed to index any suffix on Windows, so bare-name links in directory-index files never resolved (issue #69).
+
 Resolution is handled by [[src/lattice.ts#resolveRef]] for strict contexts (`lat check`, `lat refs`) where authored links must resolve unambiguously. Lenient contexts (`lat locate`, `lat expand`) use [[src/lattice.ts#findSections]] directly, which has its own file stem expansion built in — it does not call `resolveRef`.
 
 ## Refs Extraction

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",
-    "format": "prettier --write 'src/**/*.ts'",
-    "format:check": "prettier --check 'src/**/*.ts'",
+    "format": "prettier --write \"src/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\"",
     "cook-test-rag": "tsx scripts/cook-test-rag.ts"
   },
   "devDependencies": {

--- a/src/code-refs.ts
+++ b/src/code-refs.ts
@@ -1,7 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { execFile } from 'node:child_process';
 import { join, relative } from 'node:path';
-import { walkEntries } from './walk.js';
+import { toPosix, walkEntries } from './walk.js';
 
 /** Glob patterns used to exclude directories/files from code-ref scanning.
  *  Shared between rg args and the TS fallback's walkFiles filter. */
@@ -112,8 +112,10 @@ async function findSubProjects(projectRoot: string): Promise<string[]> {
   if (!out) return [];
 
   const subProjects = new Set<string>();
-  for (const line of out.split('\n')) {
-    if (!line) continue;
+  for (const rawLine of out.split('\n')) {
+    if (!rawLine) continue;
+    // rg emits native separators on Windows; normalize before matching '/lat.md/'.
+    const line = toPosix(rawLine);
     const clean = line.startsWith('./') ? line.slice(2) : line;
     // "tests/cases/foo/lat.md/specs.md" → "tests/cases/foo"
     // Skip root lat.md/ (no parent prefix — starts with "lat.md/")
@@ -168,7 +170,7 @@ async function tryRipgrep(
     .split('\n')
     .filter(Boolean)
     .map((f) => {
-      const clean = f.startsWith('./') ? f.slice(2) : f;
+      const clean = toPosix(f).replace(/^\.\//, '');
       return join(projectRoot, clean);
     });
 
@@ -194,7 +196,10 @@ function parseGrepOutput(
     const secondColon = line.indexOf(':', firstColon + 1);
     if (secondColon === -1) continue;
 
-    let filePath = line.slice(0, firstColon);
+    // rg emits native separators (`\` on Windows); normalize to POSIX so the
+    // stored path matches wiki-link and TS-fallback conventions. This also
+    // turns a Windows `.\` prefix into `./` for the strip below.
+    let filePath = toPosix(line.slice(0, firstColon));
     const lineNum = parseInt(line.slice(firstColon + 1, secondColon), 10);
     const content = line.slice(secondColon + 1);
 
@@ -240,7 +245,7 @@ async function scanWithTs(
       while ((match = LAT_REF_RE.exec(lines[i])) !== null) {
         refs.push({
           target: match[1],
-          file: relative(projectRoot, file),
+          file: toPosix(relative(projectRoot, file)),
           line: i + 1,
         });
       }

--- a/src/lattice.ts
+++ b/src/lattice.ts
@@ -2,7 +2,7 @@ import { readFile } from 'node:fs/promises';
 import { dirname, join, basename, relative, resolve } from 'node:path';
 import { existsSync, statSync } from 'node:fs';
 import { parse } from './parser.js';
-import { walkEntries } from './walk.js';
+import { toPosix, walkEntries } from './walk.js';
 import { visit } from 'unist-util-visit';
 import type { Heading, RootContent, Text } from 'mdast';
 import type { WikiLink } from './extensions/wiki-link/types.js';
@@ -99,10 +99,10 @@ export function parseSections(
 ): Section[] {
   const tree = parse(content);
   const file = projectRoot
-    ? relative(projectRoot, filePath).replace(/\.md$/, '')
+    ? toPosix(relative(projectRoot, filePath)).replace(/\.md$/, '')
     : basename(filePath, '.md');
   const sectionFilePath = projectRoot
-    ? relative(projectRoot, filePath)
+    ? toPosix(relative(projectRoot, filePath))
     : basename(filePath);
   const roots: Section[] = [];
   const stack: Section[] = [];
@@ -619,7 +619,7 @@ export function extractRefs(
 ): Ref[] {
   const tree = parse(content);
   const file = projectRoot
-    ? relative(projectRoot, filePath).replace(/\.md$/, '')
+    ? toPosix(relative(projectRoot, filePath)).replace(/\.md$/, '')
     : basename(filePath, '.md');
   const refs: Ref[] = [];
 

--- a/src/walk.ts
+++ b/src/walk.ts
@@ -17,3 +17,15 @@ export function walkEntries(dir: string): Promise<string[]> {
     entries.filter((e: string) => !e.startsWith('.git/') && !e.startsWith('.')),
   );
 }
+
+/**
+ * Normalize a filesystem path to forward-slash (POSIX) form. Node's
+ * `path.relative()` emits the native separator (`\` on Windows), but section
+ * ids, wiki-link targets, and the code-ref data model are all forward-slash
+ * based. Normalizing every OS-relative path through here at construction keeps
+ * a single invariant — stored paths are always POSIX — so downstream lookups
+ * (e.g. `buildFileIndex`, ref resolution) work identically on every platform.
+ */
+export function toPosix(p: string): string {
+  return p.replace(/\\/g, '/');
+}

--- a/tests/hook.test.ts
+++ b/tests/hook.test.ts
@@ -1,13 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import { join, delimiter } from 'node:path';
-import { mkdtempSync, rmSync, writeFileSync, chmodSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, chmodSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-
-/** Remove a temp dir, retrying on transient Windows locks (EBUSY/EPERM). */
-function rmDir(dir: string): void {
-  rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
-}
+import { rmDirBestEffort } from './util.js';
 
 const casesDir = join(import.meta.dirname, 'cases');
 const cliPath = join(
@@ -112,7 +108,7 @@ describe('hook stop', () => {
       expect(stdout).toBe('');
       expect(stderr).toBe('');
     } finally {
-      rmDir(fakeBinDir);
+      rmDirBestEffort(fakeBinDir);
     }
   });
 
@@ -137,7 +133,7 @@ describe('hook stop', () => {
       expect(parsed.reason).toContain('110');
       expect(parsed.reason).toContain('lat.md/');
     } finally {
-      rmDir(fakeBinDir);
+      rmDirBestEffort(fakeBinDir);
     }
   });
 
@@ -150,7 +146,7 @@ describe('hook stop', () => {
       const { stdout } = runStopHook('claude', clean, { fakeBinDir });
       expect(stdout).toBe('');
     } finally {
-      rmDir(fakeBinDir);
+      rmDirBestEffort(fakeBinDir);
     }
   });
 
@@ -161,7 +157,7 @@ describe('hook stop', () => {
       const { stdout } = runStopHook('claude', clean, { fakeBinDir });
       expect(stdout).toBe('');
     } finally {
-      rmDir(fakeBinDir);
+      rmDirBestEffort(fakeBinDir);
     }
   });
 
@@ -175,7 +171,7 @@ describe('hook stop', () => {
       expect(parsed.reason).toContain('Update `lat.md/`');
       expect(parsed.reason).toContain('lat check` until it passes');
     } finally {
-      rmDir(fakeBinDir);
+      rmDirBestEffort(fakeBinDir);
     }
   });
 
@@ -204,7 +200,7 @@ describe('hook stop', () => {
       const { stdout } = runStopHook('claude', clean, { fakeBinDir });
       expect(stdout).toBe('');
     } finally {
-      rmDir(fakeBinDir);
+      rmDirBestEffort(fakeBinDir);
     }
   });
 
@@ -220,7 +216,7 @@ describe('hook stop', () => {
       expect(parsed.followup_message).toContain('110');
       expect(parsed.decision).toBeUndefined();
     } finally {
-      rmDir(fakeBinDir);
+      rmDirBestEffort(fakeBinDir);
     }
   });
 });

--- a/tests/hook.test.ts
+++ b/tests/hook.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { join } from 'node:path';
+import { join, delimiter } from 'node:path';
 import { mkdtempSync, rmSync, writeFileSync, chmodSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+
+/** Remove a temp dir, retrying on transient Windows locks (EBUSY/EPERM). */
+function rmDir(dir: string): void {
+  rmSync(dir, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+}
 
 const casesDir = join(import.meta.dirname, 'cases');
 const cliPath = join(
@@ -19,15 +24,27 @@ function numstat(files: [number, number, string][]): string {
   return files.map(([a, r, f]) => `${a}\t${r}\t${f}`).join('\n');
 }
 
-/** Create a temp dir with a fake `git` script that outputs the given numstat. */
+/**
+ * Create a temp dir with a fake `git` that prints the given numstat regardless
+ * of args. Cross-platform: the payload is stored in a data file (preserving the
+ * tab separators), and both a POSIX `git` shell script and a Windows `git.cmd`
+ * batch shim emit it — so the hook's `git diff --numstat` is intercepted on
+ * every OS. Callers prepend this dir to PATH.
+ */
 function makeFakeGitDir(output: string): string {
   const dir = mkdtempSync(join(tmpdir(), 'lat-hook-'));
-  const gitScript = join(dir, 'git');
-  writeFileSync(
-    gitScript,
-    '#!/bin/sh\n' + "cat <<'NUMSTAT'\n" + output + '\nNUMSTAT\n',
-  );
-  chmodSync(gitScript, 0o755);
+  const dataFile = join(dir, 'numstat.txt');
+  writeFileSync(dataFile, output);
+
+  // POSIX: `git` shell script.
+  const shScript = join(dir, 'git');
+  writeFileSync(shScript, '#!/bin/sh\ncat "$(dirname "$0")/numstat.txt"\n');
+  chmodSync(shScript, 0o755);
+
+  // Windows: `git.cmd` batch shim (resolved via PATHEXT). `type` preserves tabs.
+  const cmdScript = join(dir, 'git.cmd');
+  writeFileSync(cmdScript, '@type "%~dp0numstat.txt"\r\n');
+
   return dir;
 }
 
@@ -49,7 +66,13 @@ function runHook(
     ...(process.env as Record<string, string>),
   };
   if (opts.fakeBinDir) {
-    env.PATH = opts.fakeBinDir + ':' + env.PATH;
+    // Prepend using the OS path delimiter (';' on Windows). Windows env vars are
+    // case-insensitive, so drop any existing `Path` key before setting `PATH` to
+    // avoid the child inheriting the unmodified value under a different casing.
+    const orig = env.PATH ?? env.Path ?? '';
+    delete env.Path;
+    delete env.PATH;
+    env.PATH = opts.fakeBinDir + delimiter + orig;
   }
 
   const result = spawnSync('node', [cliPath, 'hook', agent, event], {
@@ -89,7 +112,7 @@ describe('hook stop', () => {
       expect(stdout).toBe('');
       expect(stderr).toBe('');
     } finally {
-      rmSync(fakeBinDir, { recursive: true });
+      rmDir(fakeBinDir);
     }
   });
 
@@ -114,7 +137,7 @@ describe('hook stop', () => {
       expect(parsed.reason).toContain('110');
       expect(parsed.reason).toContain('lat.md/');
     } finally {
-      rmSync(fakeBinDir, { recursive: true });
+      rmDir(fakeBinDir);
     }
   });
 
@@ -127,7 +150,7 @@ describe('hook stop', () => {
       const { stdout } = runStopHook('claude', clean, { fakeBinDir });
       expect(stdout).toBe('');
     } finally {
-      rmSync(fakeBinDir, { recursive: true });
+      rmDir(fakeBinDir);
     }
   });
 
@@ -138,7 +161,7 @@ describe('hook stop', () => {
       const { stdout } = runStopHook('claude', clean, { fakeBinDir });
       expect(stdout).toBe('');
     } finally {
-      rmSync(fakeBinDir, { recursive: true });
+      rmDir(fakeBinDir);
     }
   });
 
@@ -152,7 +175,7 @@ describe('hook stop', () => {
       expect(parsed.reason).toContain('Update `lat.md/`');
       expect(parsed.reason).toContain('lat check` until it passes');
     } finally {
-      rmSync(fakeBinDir, { recursive: true });
+      rmDir(fakeBinDir);
     }
   });
 
@@ -181,7 +204,7 @@ describe('hook stop', () => {
       const { stdout } = runStopHook('claude', clean, { fakeBinDir });
       expect(stdout).toBe('');
     } finally {
-      rmSync(fakeBinDir, { recursive: true });
+      rmDir(fakeBinDir);
     }
   });
 
@@ -197,7 +220,7 @@ describe('hook stop', () => {
       expect(parsed.followup_message).toContain('110');
       expect(parsed.decision).toBeUndefined();
     } finally {
-      rmSync(fakeBinDir, { recursive: true });
+      rmDir(fakeBinDir);
     }
   });
 });

--- a/tests/lattice.test.ts
+++ b/tests/lattice.test.ts
@@ -4,7 +4,10 @@ import {
   findLatticeDir,
   listLatticeFiles,
   parseSections,
+  buildFileIndex,
+  resolveRef,
 } from '../src/lattice.js';
+import { toPosix } from '../src/walk.js';
 
 const basicDir = join(import.meta.dirname, 'cases', 'basic-project');
 const basicLat = join(basicDir, 'lat.md');
@@ -40,5 +43,50 @@ describe('parseSections', () => {
   it('uses file stem without .md extension', () => {
     const sections = parseSections('/path/to/notes.md', '# Hello');
     expect(sections[0].file).toBe('notes');
+  });
+});
+
+describe('toPosix', () => {
+  it('converts native backslash separators to forward slashes', () => {
+    expect(toPosix('codigo\\codigo.md')).toBe('codigo/codigo.md');
+    expect(toPosix('lat.md\\codigo\\a')).toBe('lat.md/codigo/a');
+  });
+
+  it('leaves POSIX paths unchanged', () => {
+    expect(toPosix('lat.md/codigo/a')).toBe('lat.md/codigo/a');
+    expect(toPosix('notes')).toBe('notes');
+    expect(toPosix('')).toBe('');
+  });
+});
+
+// Regression guard for issue #69: on Windows, section file paths kept the
+// native `\` separator, so bare-name (`[[a]]`) links in a directory-index file
+// never resolved. Section paths are now normalized to POSIX at construction, so
+// this scenario resolves identically on every OS. The windows-latest CI job
+// runs this same test on the platform where the bug originally manifested.
+describe('bare-name link resolution in a subdirectory (issue #69)', () => {
+  const root = join('/tmp', 'proj');
+  const parse = (rel: string, body: string) =>
+    parseSections(join(root, 'lat.md', rel), body, root);
+
+  it('resolves short-form links to sibling files in the same subdir', () => {
+    const sections = [
+      ...parse('codigo/a.md', '# A\n\nAlpha.\n'),
+      ...parse('codigo/b.md', '# B\n\nBravo.\n'),
+      ...parse('codigo/codigo.md', '# Codigo\n\nDirectory index.\n'),
+    ];
+
+    // The invariant the fix enforces: stored paths are POSIX on every platform.
+    expect(sections.map((s) => s.file)).toContain('lat.md/codigo/a');
+    expect(sections.every((s) => !s.file.includes('\\'))).toBe(true);
+
+    const fileIndex = buildFileIndex(sections);
+    const sectionIds = new Set(sections.map((s) => s.id.toLowerCase()));
+
+    for (const name of ['a', 'b']) {
+      const { resolved, ambiguous } = resolveRef(name, sectionIds, fileIndex);
+      expect(ambiguous).toBeNull();
+      expect(sectionIds.has(resolved.toLowerCase())).toBe(true);
+    }
   });
 });

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { join } from 'node:path';
-import { mkdtempSync, rmSync, cpSync } from 'node:fs';
+import { mkdtempSync, cpSync } from 'node:fs';
 import { tmpdir } from 'node:os';
+import { rmDirBestEffort } from './util.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { startReplayServer, hasReplayData } from './rag-replay-server.js';
@@ -158,7 +159,7 @@ describe.skipIf(!canRunSearch)('mcp search (rag)', () => {
   afterAll(async () => {
     await client.close();
     if (server) server.close();
-    if (tmp) rmSync(tmp, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    if (tmp) rmDirBestEffort(tmp);
   });
 
   // @lat: [[tests/mcp#lat_search finds auth section]]
@@ -212,6 +213,6 @@ describe.skipIf(!canRunSearch)('mcp search (rag)', () => {
     expect(text).toContain('Authentication');
 
     await client2.close();
-    rmSync(tmp2, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    rmDirBestEffort(tmp2);
   });
 });

--- a/tests/mcp.test.ts
+++ b/tests/mcp.test.ts
@@ -158,7 +158,7 @@ describe.skipIf(!canRunSearch)('mcp search (rag)', () => {
   afterAll(async () => {
     await client.close();
     if (server) server.close();
-    if (tmp) rmSync(tmp, { recursive: true, force: true });
+    if (tmp) rmSync(tmp, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   // @lat: [[tests/mcp#lat_search finds auth section]]
@@ -212,6 +212,6 @@ describe.skipIf(!canRunSearch)('mcp search (rag)', () => {
     expect(text).toContain('Authentication');
 
     await client2.close();
-    rmSync(tmp2, { recursive: true, force: true });
+    rmSync(tmp2, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 });

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -64,7 +64,7 @@ describe('search (rag, local)', () => {
 
   afterAll(async () => {
     if (db) await closeDb(db);
-    if (latDir) rmSync(join(latDir, '..'), { recursive: true, force: true });
+    if (latDir) rmSync(join(latDir, '..'), { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   // @lat: [[search#RAG Tests#Indexes all sections]]
@@ -175,8 +175,8 @@ describe('search (rag, legacy cache upgrade)', () => {
         if (saved[k] === undefined) delete process.env[k];
         else process.env[k] = saved[k];
       }
-      rmSync(cfg, { recursive: true, force: true });
-      rmSync(join(latDir, '..'), { recursive: true, force: true });
+      rmSync(cfg, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      rmSync(join(latDir, '..'), { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
     }
   });
 });
@@ -227,7 +227,7 @@ describe.skipIf(!canRunHosted)('search (rag, hosted replay)', () => {
     if (capturing) flushCapture();
     if (db) await closeDb(db);
     if (server) server.close();
-    if (latDir) rmSync(join(latDir, '..'), { recursive: true, force: true });
+    if (latDir) rmSync(join(latDir, '..'), { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
   });
 
   it('indexes and finds the auth section via the hosted backend', async () => {

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { mkdtempSync, rmSync, cpSync } from 'node:fs';
 import { join } from 'node:path';
+import { rmDirBestEffort } from './util.js';
 import { tmpdir } from 'node:os';
 import { detectProvider, createEmbedder, type Embedder } from '@lat.md/embed';
 import minilm from '@lat.md/embed-minilm-fp16';
@@ -64,7 +65,7 @@ describe('search (rag, local)', () => {
 
   afterAll(async () => {
     if (db) await closeDb(db);
-    if (latDir) rmSync(join(latDir, '..'), { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    if (latDir) rmDirBestEffort(join(latDir, '..'));
   });
 
   // @lat: [[search#RAG Tests#Indexes all sections]]
@@ -175,8 +176,8 @@ describe('search (rag, legacy cache upgrade)', () => {
         if (saved[k] === undefined) delete process.env[k];
         else process.env[k] = saved[k];
       }
-      rmSync(cfg, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
-      rmSync(join(latDir, '..'), { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+      rmDirBestEffort(cfg);
+      rmDirBestEffort(join(latDir, '..'));
     }
   });
 });
@@ -227,7 +228,7 @@ describe.skipIf(!canRunHosted)('search (rag, hosted replay)', () => {
     if (capturing) flushCapture();
     if (db) await closeDb(db);
     if (server) server.close();
-    if (latDir) rmSync(join(latDir, '..'), { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    if (latDir) rmDirBestEffort(join(latDir, '..'));
   });
 
   it('indexes and finds the auth section via the hosted backend', async () => {

--- a/tests/util.ts
+++ b/tests/util.ts
@@ -1,0 +1,21 @@
+import { rmSync } from 'node:fs';
+
+/**
+ * Remove a temp dir, tolerating Windows file locks. libsql keeps the index file
+ * (`lat.md/.cache/vectors.db`) locked briefly after `close()`, and a
+ * just-executed `.cmd` shim can linger — Windows refuses to unlink either.
+ * Retry with backoff, then give up quietly: a leftover dir under the OS temp
+ * root is harmless on ephemeral CI runners, and cleanup is not under test.
+ */
+export function rmDirBestEffort(dir: string): void {
+  try {
+    rmSync(dir, {
+      recursive: true,
+      force: true,
+      maxRetries: 10,
+      retryDelay: 150,
+    });
+  } catch {
+    // Ignore EBUSY/EPERM/ENOTEMPTY — see doc comment.
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    // The cold WASM embedder build and a full `tsc --noEmit` run legitimately
+    // exceed vitest's 5s default on slower runners (notably Windows CI). Give
+    // heavy tests and their beforeAll hooks generous headroom.
+    testTimeout: 30000,
+    hookTimeout: 30000,
+  },
+})


### PR DESCRIPTION
Fixes #69.

## The bug
On Windows, `lat check` reported false-positive `broken link` errors for every short-form `[[<name>]]` link in a directory-index file. Section paths were built from node's `path.relative()`, which emits the native `\` separator on Windows. `buildFileIndex` splits those on `/`, so `'codigo\codigo.md'.split('/')` returned the whole string, the bare-name lookup table stayed empty, and no short link resolved.

## The fix
Normalize every OS-relative path to forward slashes **at construction**, so the data model has a single invariant — stored paths are always POSIX — and all downstream lookups (id matching, `buildFileIndex`, ref/code-ref resolution) work identically on every platform. Display paths (relative to cwd, for error output) stay native.

- New `toPosix()` helper in `src/walk.ts`.
- Applied in `parseSections`, `extractRefs` (`src/lattice.ts`) and the code-ref scanner (`src/code-refs.ts`): TS-fallback `CodeRef.file`, rg-output path parsing (also handles the Windows `.\` prefix), and sub-project detection (so nested `lat.md/` dirs are still excluded on Windows).

## Tests & CI
- Portable regression test reproducing the subdirectory bare-name scenario from the issue, plus `toPosix` unit tests (161 tests pass locally).
- **Windows CI**: the suite now runs on a `[ubuntu-latest, windows-latest]` matrix (`fail-fast: false`) — this PR's own CI run is the real end-to-end guard on Windows.
- `.gitattributes` (`eol=lf`) so Windows checkouts don't rewrite line endings and break the parser/roundtrip tests.

## Docs
- `lat.md/parser.md` documents the POSIX-path invariant and links `toPosix`. `lat check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)