### PR TITLE
Release 0.12.1 — Windows path-separator fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lat.md",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "A knowledge graph for your codebase, written in markdown",
   "type": "module",
   "packageManager": "pnpm@10.30.2",

--- a/website/app/page.tsx
+++ b/website/app/page.tsx
@@ -172,7 +172,7 @@ export default function Home() {
             }}
           >
             {[
-              { v: '0.12', text: <>Offline semantic search — <Cmd>lat search</Cmd> works with no API key via a bundled local WASM embedding model; new <Cmd>lat reindex</Cmd> command to rebuild the index and switch backends</> },
+              { v: '0.12', text: <>Offline semantic search — <Cmd>lat search</Cmd> works with no API key via a bundled local WASM embedding model; new <Cmd>lat reindex</Cmd> command to rebuild the index and switch backends; Windows support</> },
               { v: '0.11', text: <><Cmd>lat init</Cmd> supports Codex, OpenCode, and Cursor stop hook</> },
               { v: '0.10', text: <><Cmd>lat section</Cmd> and <Cmd>lat refs</Cmd> show source code snippets; ripgrep-powered code scanning</> },
               { v: '0.9', text: <><Cmd>lat init</Cmd> creates a lat skill for supported agents</> },


### PR DESCRIPTION
## lat.md 0.12.1

Patch release. The Windows fix (#69) is already merged to `main`; this bumps the version so it publishes.

### Fixes
- **`lat check` now works on Windows.** Section, ref, and code-ref paths were built with node's native `\` separator, so bare-name `[[link]]`s in directory-index files never resolved (`buildFileIndex` splits on `/`). Paths are now normalized to POSIX at construction. (#69)

### Internal
- CI runs the full suite on a `[ubuntu-latest, windows-latest]` matrix, which surfaced and fixed the above plus several Windows-only test/tooling issues (prettier glob quoting, fake-`git` shim, test timeouts, libsql file-lock cleanup). `.gitattributes` pins `eol=lf`.

### Packaging
- Only the root `lat.md` changed → `0.12.0` → `0.12.1`. `@lat.md/embed@0.2.0` and `@lat.md/embed-minilm-fp16@0.1.0` are unchanged and already on npm, so `publish_if_new` skips them; only `lat.md@0.12.1` publishes on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)