### PR TITLE
Release 0.12.2 — Windows code-ref resolution fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lat.md",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "description": "A knowledge graph for your codebase, written in markdown",
   "type": "module",
   "packageManager": "pnpm@10.30.2",


### PR DESCRIPTION
## lat.md 0.12.2

Patch release for the Windows code-reference regression fixed in #83.

### Fixes
- **`lat check code-refs` again accepts Windows-style backslash paths.** References retained from before v0.12.1 are normalized to canonical POSIX section IDs before strict resolution. (#82)
- **`lat locate` resolves those same paths exactly.** It now returns one exact match instead of falling through to fuzzy matches.
- Normalization is limited to the file portion before the first `#`, preserving authored heading text.

### Packaging
- Only the root `lat.md` package changed: `0.12.1` → `0.12.2`.
- `@lat.md/embed@0.2.0` and `@lat.md/embed-minilm-fp16@0.1.0` are unchanged and already published, so the publish workflow will skip them.

### Validation
- `pnpm buildall`
- `pnpm test` — 163 tests passed
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm exec lat check`

Fixes #82